### PR TITLE
feat: 添加Web应用界面用于文档清洗和转换

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,7 @@ htmlcov/
 # Test directories for E2E tests
 test_input_e2e/
 test_output_e2e/
+
+# Flask Web App specific (temporary storage)
+webapp/uploads/
+webapp/results/

--- a/README.md
+++ b/README.md
@@ -129,9 +129,149 @@ python -m auto_doc_markdown_converter.main <input_path> <output_dir> [options]
     python -m auto_doc_markdown_converter.main ./input_document_folder/ ./processed_markdown_files/
     ```
 
-## 🔄 工作流程
+## 🌐 运行 Web 应用 (Flask)
 
-本工具处理文档的流程如下：
+除了命令行界面，本项目还提供了一个基于 Flask 的 Web 应用，允许用户通过浏览器上传文档并获取转换后的 Markdown。
+
+### 前提条件
+
+1.  **完成安装**: 请确保您已按照 [环境要求与安装](#️-环境要求与安装) 部分的说明完成了所有依赖的安装 (特别是 `Flask`，它已包含在 `requirements.txt` 中)。
+2.  **配置环境变量**: 运行 Web 应用前，必须正确设置 [配置](#️-配置) 部分描述的环境变量 (`LLM_API_KEY`, `LLM_API_ENDPOINT`, 以及可选的 `LLM_MODEL_ID`)。这些变量对于 Web 应用的核心文档处理功能同样至关重要。
+
+### 启动 Web 应用
+
+您可以选择以下任一方式从项目的根目录启动 Flask 开发服务器：
+
+**方式一：直接运行 `app.py`**
+
+这种方式简单直接，适合快速启动。
+
+```bash
+# 确保您当前位于项目的根目录下
+python webapp/app.py
+```
+启动后，应用通常会监听 `http://0.0.0.0:5000/` 或 `http://127.0.0.1:5000/`。控制台输出会显示确切的监听地址。
+
+**方式二：使用 `flask run` 命令 (推荐)**
+
+这是 Flask 官方推荐的启动开发服务器的方式，提供了更灵活的配置选项。
+
+1.  **设置必要的环境变量** (只需在当前终端会话设置一次，或将其添加到您的 shell 配置文件中，如 `.bashrc`, `.zshrc` 等):
+
+    *   **Linux/macOS**:
+        ```bash
+        export FLASK_APP=webapp/app.py
+        export FLASK_ENV=development  # 启用调试模式，生产环境请勿使用
+        ```
+    *   **Windows (CMD)**:
+        ```cmd
+        set FLASK_APP=webapp\app.py
+        set FLASK_ENV=development
+        ```
+    *   **Windows (PowerShell)**:
+        ```powershell
+        $env:FLASK_APP="webapp\app.py"
+        $env:FLASK_ENV="development"
+        ```
+    *   **说明**:
+        *   `FLASK_APP` 指向 Flask 应用的入口文件。
+        *   `FLASK_ENV=development` 会启用调试模式，这在开发阶段非常有用，但在生产环境中不应使用。
+
+2.  **运行 Flask 应用**:
+    ```bash
+    flask run --host=0.0.0.0 --port=5000
+    ```
+    *   `--host=0.0.0.0` 使服务器可以从网络中的任何 IP 地址访问（对于虚拟机或容器环境很方便），如果只想本机访问，可以省略或使用 `127.0.0.1`。
+    *   `--port=5000` 指定监听端口，您可以根据需要更改。
+    *   如果已设置 `FLASK_ENV=development`，则通常无需显式传递 `--debug` 选项给 `flask run`。
+
+### 访问 Web 应用
+
+启动成功后，打开您的 Web 浏览器，并访问控制台输出中显示的地址，通常是：
+
+```
+http://127.0.0.1:5000/
+```
+
+您应该能看到 "Flask Web App 正在运行!" 的消息。后续步骤将实现文件上传和下载的用户界面。
+
+## 🧪 手动测试 Web 应用
+
+在您按照前面的说明成功安装了所有依赖、配置了必要的环境变量并启动了 Flask Web 应用后，您可以按照以下步骤手动测试其功能。
+
+**前提条件:**
+1.  **Python 环境已配置**: 确保您的 Python 环境 (推荐 Python 3.8+) 已设置，并且项目的虚拟环境（如果使用）已激活。
+2.  **依赖已安装**: 已在项目根目录下运行 `pip install -r requirements.txt`。
+3.  **环境变量已设置**:
+    *   `LLM_API_KEY`: 设置为您的有效 DashScope API 密钥。
+    *   `LLM_API_ENDPOINT`: 设置为 DashScope OpenAI 兼容模式的基础 URL (例如, `https://dashscope.aliyuncs.com/compatible-mode/v1`)。
+    *   `LLM_MODEL_ID`: (可选) 设置为您希望使用的模型 ID (例如, `qwen-plus`)。如果未设置，将使用默认模型。
+    *   **注意**: 对于当前阶段的测试，如果您想完全模拟而不产生实际的 LLM API 调用费用，您可以临时修改 `auto_doc_markdown_converter/src/llm_processor.py` 文件，在 `analyze_text_with_llm` 函数的开头直接返回一个固定的模拟字符串，例如：
+        ```python
+        # auto_doc_markdown_converter/src/llm_processor.py
+        def analyze_text_with_llm(text: str) -> Optional[str]: # 确保导入 Optional
+            logger.info("LLM 分析被 Mock，返回固定模拟输出。")
+            return "H1: 模拟标题\nP: 这是一个通过 Mock LLM 生成的模拟段落。"
+            # ... (原有的真实 API 调用逻辑) ...
+        ```
+        测试完毕后，请记得移除或注释掉此 mock 代码以恢复真实 LLM 调用。
+4.  **Web 应用已启动**: 按照 "[运行 Web 应用 (Flask)](#️-运行-web-应用-flask)" 部分的说明，已成功启动 Flask 开发服务器 (例如，通过 `python webapp/app.py`)。服务器应在控制台显示正在运行，并监听类似 `http://127.0.0.1:5000/` 的地址。
+
+**测试步骤:**
+
+1.  **访问 Web 界面**:
+    *   打开您的 Web 浏览器 (推荐使用 Chrome, Firefox 等现代浏览器)。
+    *   在地址栏输入 Flask 应用运行的地址 (通常是 `http://127.0.0.1:5000/`) 并回车。
+    *   **预期结果**: 您应该能看到“智能文档清洗与 Markdown 转换工具”的页面，包含文件选择区域和“开始处理”按钮，并且页面样式已正确加载。
+
+2.  **测试单个文件上传与处理**:
+    *   准备一个小型、有效的 `.docx` 文件 (例如，内容为 "你好世界" 的 `test_doc.docx`)。
+    *   点击页面上的“选择文件”或类似按钮，选择您准备的 `test_doc.docx` 文件。
+    *   点击“开始处理”按钮。
+    *   **预期行为与结果**:
+        *   页面上的状态区域 (`uploadStatus`) 应依次显示类似“正在准备上传...”、“正在上传文件...”、“正在处理文件，请稍候...”、“处理完成！”的提示。
+        *   在“处理结果”区域 (`resultsArea`)，应出现一个针对 `test_doc.docx` 的条目，显示：
+            *   原始文件名。
+            *   处理状态为“处理成功”。
+            *   一个名为 `test_doc.md` (或类似) 的下载链接。
+            *   一个“预览 Markdown”按钮。
+        *   点击“预览 Markdown”按钮：页面上应在该条目下方动态加载并显示 Markdown 内容的预览。如果使用了上述的 LLM mock，预览内容应为：
+            ```
+            H1: 模拟标题
+            P: 这是一个通过 Mock LLM 生成的模拟段落。
+            ```
+            (实际 Markdown 渲染后可能是： `# 模拟标题\n\n这是一个通过 Mock LLM 生成的模拟段落。`)
+        *   点击下载链接：浏览器应开始下载 `test_doc.md` 文件。打开该文件，其内容应与预览内容一致。
+    *   重复此步骤，但使用一个小型、有效的 `.pdf` 文件进行测试。预期行为和结果类似。
+
+3.  **测试多个文件上传与处理**:
+    *   准备一个 `.docx` 文件和一个 `.pdf` 文件。
+    *   点击“选择文件”按钮，同时选中这两个文件。
+    *   点击“开始处理”按钮。
+    *   **预期行为与结果**:
+        *   状态区域正常更新。
+        *   “处理结果”区域应为这两个文件分别显示处理结果条目，每个条目都应包含成功的状态、下载链接和预览按钮。
+        *   分别测试每个文件的下载和预览功能，应均能正常工作。
+
+4.  **测试不支持的文件类型**:
+    *   准备一个文本文件 (例如 `.txt`) 或图片文件 (例如 `.jpg`)。
+    *   选择该文件并点击“开始处理”。
+    *   **预期行为与结果**:
+        *   在“处理结果”区域，该文件的条目应显示处理状态为“处理失败”，并给出类似“不支持的文件类型”的错误信息。
+
+5.  **测试未选择文件即提交**:
+    *   不选择任何文件，直接点击“开始处理”按钮。
+    *   **预期行为与结果**:
+        *   页面应给出提示，例如在“处理结果”区域显示“请至少选择一个文件。”。
+
+**问题排查提示:**
+*   如果在测试过程中遇到问题，请首先检查运行 Flask 应用的服务器控制台。通常，详细的错误信息和日志会输出在那里。
+*   确认所有环境变量都已正确设置并对 Flask 应用可见。
+*   打开浏览器的开发者工具 (通常按 F12)，检查“控制台 (Console)”和“网络 (Network)”面板，看是否有前端 JavaScript 错误或 API 请求失败的信息。
+
+---
+
+## 🔄 工作流程
 
 1.  **参数解析与环境检查**:
     *   程序首先解析用户通过命令行提供的输入路径、输出目录和选项。

--- a/auto_doc_markdown_converter/src/__init__.py
+++ b/auto_doc_markdown_converter/src/__init__.py
@@ -1,9 +1,35 @@
-# __init__.py for the src directory
+"""
+auto_doc_markdown_converter.src 包初始化文件。
 
+此包包含了应用程序的核心处理逻辑、模块化组件以及配置。
+通过导入 `process_document_to_markdown` 函数，提供了一个便捷的
+核心功能调用入口。同时，也使得 `config` 和 `utils` 等基础模块
+可以从包级别访问。
+"""
+# 导入项目的主要配置和工具
 from . import config
-from . import llm_processor
 from . import utils
+
+# 导入各个处理模块 (这些通常由核心处理器或主应用间接使用)
 from . import docx_extractor
-from . import file_handler
 from . import pdf_extractor
+from . import file_handler
+from . import llm_processor
 from . import markdown_generator
+
+# 导入并导出核心处理函数，使其可从 src 包直接访问
+from .core_processor import process_document_to_markdown
+
+# 定义 __all__ 以明确指定从 "from src import *" 时应导入的内容
+# 这有助于控制命名空间并提供清晰的公共 API。
+__all__ = [
+    'config',           # 应用程序配置
+    'utils',            # 通用工具函数 (例如 setup_logging)
+    'process_document_to_markdown', # 核心文档处理函数
+    # 以下模块通常不直接从 src 导入，而是通过其功能被调用，但可以根据需要添加
+    # 'file_handler',
+    # 'llm_processor',
+    # 'markdown_generator',
+    # 'docx_extractor',
+    # 'pdf_extractor',
+]

--- a/auto_doc_markdown_converter/src/core_processor.py
+++ b/auto_doc_markdown_converter/src/core_processor.py
@@ -1,0 +1,108 @@
+import os
+import logging
+from typing import Optional # 用于类型提示
+
+from .file_handler import get_file_type, read_file_content
+from .llm_processor import analyze_text_with_llm
+from .markdown_generator import generate_markdown_from_labeled_text
+from .config import API_KEY, API_ENDPOINT
+
+def process_document_to_markdown(input_filepath: str, results_dir: str) -> Optional[str]:
+    """
+    处理单个文档（.docx 或 .pdf），将其转换为 Markdown 文件并保存到指定目录。
+
+    该函数封装了文档处理的核心逻辑：文件类型识别、内容读取、LLM 分析、
+    Markdown 生成以及结果保存。
+
+    参数:
+        input_filepath (str): 要处理的单个文档的完整路径。
+        results_dir (str): 用于保存生成的 .md 文件的目录路径。
+
+    返回:
+        Optional[str]: 如果处理成功，则返回生成的 Markdown 文件的完整路径。
+                       如果任何步骤失败或文件不受支持，则返回 None。
+    """
+    logger = logging.getLogger(__name__)
+    logger.info(f"开始处理文档: {input_filepath}")
+
+    # 1. 检查 API 配置 (关键步骤，确保核心功能可用)
+    if not API_KEY:
+        logger.critical("核心处理器错误：LLM_API_KEY 未配置。无法继续处理。")
+        return None
+    if not API_ENDPOINT:
+        logger.critical("核心处理器错误：LLM_API_ENDPOINT 未配置。无法继续处理。")
+        return None
+
+    # 2. 获取文件类型
+    logger.debug(f"正在获取文件 '{input_filepath}' 的类型...")
+    file_type = get_file_type(input_filepath)
+    if file_type == "unsupported":
+        logger.warning(f"文件 '{os.path.basename(input_filepath)}' 类型不受支持。已跳过。")
+        return None
+    logger.debug(f"文件类型识别为: {file_type}")
+
+    # 3. 读取文件内容
+    logger.debug(f"正在从 '{input_filepath}' (类型: {file_type}) 读取内容...")
+    try:
+        raw_text = read_file_content(input_filepath, file_type)
+        if raw_text is None:
+            # read_file_content 内部已记录具体错误 (例如，文件为空或提取失败)
+            logger.error(f"未能从文件 '{input_filepath}' 读取到有效内容。")
+            return None
+        logger.debug(f"成功从 '{input_filepath}' 读取内容 (前100字符预览: '{raw_text[:100].strip()}...')")
+    except Exception as e:
+        logger.error(f"读取文件 '{input_filepath}' 内容时发生意外的严重错误: {e}", exc_info=True)
+        return None
+
+    # 4. LLM 处理
+    logger.debug(f"正在使用 LLM 分析从 '{input_filepath}' 提取的文本...")
+    try:
+        llm_output = analyze_text_with_llm(raw_text)
+        if llm_output is None:
+            # analyze_text_with_llm 内部已记录具体错误 (例如，API 调用失败或响应无效)
+            logger.error(f"LLM 分析来自 '{input_filepath}' 的文本失败。")
+            return None
+        logger.debug(f"LLM 分析完成 (前100字符预览: '{llm_output[:100].strip()}...')")
+    except Exception as e:
+        logger.error(f"使用 LLM 分析来自 '{input_filepath}' 的文本时发生意外的严重错误: {e}", exc_info=True)
+        return None
+
+    # 5. Markdown 生成
+    logger.debug(f"正在从 LLM 输出为 '{input_filepath}' 生成 Markdown...")
+    try:
+        markdown_content = generate_markdown_from_labeled_text(llm_output)
+        if markdown_content is None or not markdown_content.strip(): # 检查是否为 None 或空/仅空白
+            logger.error(f"从 LLM 输出为 '{input_filepath}' 生成 Markdown 时出错，结果为空或无效。")
+            return None
+        logger.debug(f"Markdown 生成成功 (前100字符预览: '{markdown_content[:100].strip()}...')")
+    except Exception as e:
+        logger.error(f"从 LLM 输出为 '{input_filepath}' 生成 Markdown 时发生意外的严重错误: {e}", exc_info=True)
+        return None
+
+    # 6. 保存 Markdown 文件
+    try:
+        # 确保 results_dir 目录存在
+        os.makedirs(results_dir, exist_ok=True)
+        logger.debug(f"确保结果目录 '{results_dir}' 已存在。")
+
+        # 构造输出文件名和路径
+        base_name = os.path.splitext(os.path.basename(input_filepath))[0] + ".md"
+        output_md_path = os.path.join(results_dir, base_name)
+        logger.debug(f"Markdown 输出路径构造为: {output_md_path}")
+
+        # 写入文件
+        with open(output_md_path, "w", encoding="utf-8") as f:
+            f.write(markdown_content)
+        
+        logger.info(f"成功将处理后的 Markdown 内容保存到: {output_md_path}")
+        return output_md_path  # 返回生成的 Markdown 文件路径
+
+    except IOError as e:
+        logger.error(f"写入 Markdown 文件 '{output_md_path}' 时发生IO错误: {e}", exc_info=True)
+        return None
+    except OSError as e: # os.makedirs 可能抛出 OSError
+        logger.error(f"创建结果目录 '{results_dir}' 时发生错误: {e}", exc_info=True)
+        return None
+    except Exception as e: # 捕获其他可能的意外错误
+        logger.error(f"保存 Markdown 文件到 '{output_md_path}' 时发生意外的严重错误: {e}", exc_info=True)
+        return None

--- a/auto_doc_markdown_converter/src/llm_processor.py
+++ b/auto_doc_markdown_converter/src/llm_processor.py
@@ -21,6 +21,10 @@ def analyze_text_with_llm(text: str) -> str | None:
         LLM 识别的包含标题和段落的结构化文本。
         如果发生严重错误或 API 调用失败，则返回 None。
     """
+    # --- Mock LLM 调用已移除，恢复真实 API 调用逻辑 ---
+    # logger.info("LLM 分析被 Mock，返回固定模拟输出。")
+    # return "H1: 模拟标题\nP: 这是一个通过 Mock LLM 生成的模拟段落。"
+
     if not config.API_KEY:
         logger.critical("DashScope API 密钥 (LLM_API_KEY) 未配置。")
         return None

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ python-docx
 pdfplumber
 reportlab
 requests
+Flask

--- a/test_doc.docx
+++ b/test_doc.docx
@@ -1,0 +1,2 @@
+这是一个简单的 DOCX 测试文件，用于测试上传功能。
+Hello World from DOCX!

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -1,0 +1,179 @@
+import os
+import sys
+import logging
+from flask import Flask, request, jsonify, send_from_directory, render_template # 确保导入 render_template
+from werkzeug.utils import secure_filename
+
+# 临时解决方案：将项目根目录添加到 sys.path 以便导入 src 模块
+# 假设 webapp 目录位于项目根目录下
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from auto_doc_markdown_converter.src.core_processor import process_document_to_markdown
+# 如果 src/__init__.py 中导出了 process_document_to_markdown，也可以用：
+# from auto_doc_markdown_converter.src import process_document_to_markdown
+from auto_doc_markdown_converter.src.utils import setup_logging # 导入日志设置
+
+# 初始化 Flask 应用
+app = Flask(__name__)
+
+# 配置上传文件和结果文件的存储目录
+# UPLOAD_FOLDER 和 RESULTS_FOLDER 的定义与之前相同
+BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+UPLOAD_FOLDER = os.path.join(BASE_DIR, 'uploads')
+RESULTS_FOLDER = os.path.join(BASE_DIR, 'results')
+
+# 确保这些目录存在
+os.makedirs(UPLOAD_FOLDER, exist_ok=True)
+os.makedirs(RESULTS_FOLDER, exist_ok=True)
+
+app.config['UPLOAD_FOLDER'] = UPLOAD_FOLDER
+app.config['RESULTS_FOLDER'] = RESULTS_FOLDER
+app.config['MAX_CONTENT_LENGTH'] = 32 * 1024 * 1024  # 限制上传大小为 32MB
+
+# 获取 Flask 应用的 logger 实例
+# 在 debug=True 模式下，Flask 会自动配置一个基本的 StreamHandler
+# 如果需要更复杂的日志（例如写入文件），可以在非 debug 模式下配置
+logger = app.logger # 直接使用 Flask 的 logger
+# 或者： logger = logging.getLogger(__name__) # 如果想用模块级 logger，但需确保其处理器已配置
+
+# 允许的文件扩展名 (可以从 src.file_handler 获取，但这里为简化而硬编码)
+ALLOWED_EXTENSIONS = {'docx', 'pdf'}
+
+def allowed_file(filename):
+    """检查文件名是否具有允许的扩展名。"""
+    return '.' in filename and \
+           filename.rsplit('.', 1)[1].lower() in ALLOWED_EXTENSIONS
+
+@app.route('/')
+def index():
+    """渲染主页 (index.html)。"""
+    # 渲染 webapp/templates/index.html 文件
+    return render_template('index.html')
+
+@app.route('/upload', methods=['POST'])
+def upload_files():
+    """
+    处理文件上传并将文档转换为 Markdown。
+    支持上传多个文件。
+    """
+    if 'files[]' not in request.files:
+        logger.warning("上传请求中没有文件部分 (files[])")
+        return jsonify({"error": "请求中没有文件部分 (需要使用 'files[]' 作为字段名)"}), 400
+
+    uploaded_files = request.files.getlist("files[]")
+
+    if not uploaded_files or all(f.filename == '' for f in uploaded_files):
+        logger.warning("没有选择任何文件进行上传")
+        return jsonify({"error": "没有选择文件"}), 400
+
+    results = []
+
+    for file in uploaded_files:
+        if file and file.filename and allowed_file(file.filename):
+            original_filename = secure_filename(file.filename)
+            temp_upload_path = os.path.join(app.config['UPLOAD_FOLDER'], original_filename)
+            
+            try:
+                file.save(temp_upload_path)
+                logger.info(f"文件 '{original_filename}' 已临时保存到 '{temp_upload_path}'")
+
+                # 调用核心处理逻辑
+                markdown_file_path = process_document_to_markdown(temp_upload_path, app.config['RESULTS_FOLDER'])
+
+                if markdown_file_path:
+                    processed_filename = os.path.basename(markdown_file_path)
+                    results.append({
+                        "original_filename": original_filename,
+                        "status": "success",
+                        "processed_filename": processed_filename, # 用于后续下载
+                        "message": "文件处理成功"
+                    })
+                    logger.info(f"文件 '{original_filename}' 处理成功，输出为 '{processed_filename}'")
+                else:
+                    results.append({
+                        "original_filename": original_filename,
+                        "status": "error",
+                        "message": "文件处理失败 (核心处理器未返回有效路径，详见服务器日志)"
+                    })
+                    logger.warning(f"文件 '{original_filename}' 处理失败 (核心处理器返回 None)。")
+
+            except Exception as e:
+                logger.error(f"处理文件 '{original_filename}' 时发生严重错误: {e}", exc_info=True)
+                results.append({
+                    "original_filename": original_filename,
+                    "status": "error",
+                    "message": f"服务器内部错误: {str(e)}"
+                })
+            finally:
+                # 清理临时上传的文件
+                if os.path.exists(temp_upload_path):
+                    try:
+                        os.remove(temp_upload_path)
+                        logger.debug(f"已删除临时上传文件: {temp_upload_path}")
+                    except OSError as e_remove:
+                        logger.error(f"删除临时文件 {temp_upload_path} 失败: {e_remove}")
+        elif file and file.filename: # 文件存在但类型不允许
+            original_filename = secure_filename(file.filename)
+            logger.warning(f"文件 '{original_filename}' 的类型不被允许。")
+            results.append({
+                "original_filename": original_filename,
+                "status": "error",
+                "message": f"文件类型 '{original_filename.rsplit('.', 1)[1]}' 不受支持。请上传 .docx 或 .pdf 文件。"
+            })
+        else:
+            logger.debug("在上传列表中遇到一个无效的或没有文件名的文件部分。")
+            # 可以选择为无效部分添加一个错误条目到 results，或者静默忽略
+
+    return jsonify(results), 200
+
+
+@app.route('/download/<path:filename>', methods=['GET'])
+def download_file(filename):
+    """
+    处理文件下载请求。
+    从 RESULTS_FOLDER 安全地发送指定的文件。
+    """
+    logger.info(f"收到下载文件 '{filename}' 的请求。")
+    
+    # RESULTS_FOLDER 已经是绝对路径或相对于 app.py 的安全路径
+    results_dir = app.config['RESULTS_FOLDER']
+    
+    # 使用 secure_filename 对从 URL 获取的 filename 进行清理是一个好习惯，
+    # 尽管 send_from_directory 自身有防目录遍历机制。
+    # 但这里要注意，如果原始的 processed_filename 包含在 secure_filename 后会丢失的字符，
+    # 可能会导致文件找不到。
+    # 假设 upload_files 返回的 processed_filename 是安全的，并且不包含需要 secure_filename 清理的复杂字符。
+    # 如果 processed_filename 是直接从用户输入构造的，或者包含路径信息，则必须用 secure_filename。
+    # 在当前场景下，processed_filename 是 os.path.basename(markdown_file_path)，应该是安全的。
+
+    try:
+        logger.debug(f"尝试从目录 '{results_dir}' 发送文件 '{filename}'。")
+        return send_from_directory(results_dir, filename, as_attachment=True)
+    except FileNotFoundError:
+        logger.error(f"请求下载的文件在服务器上未找到: {os.path.join(results_dir, filename)}")
+        return jsonify({"error": "文件未找到"}), 404
+    except Exception as e:
+        logger.error(f"下载文件 '{filename}' 时发生服务器内部错误: {e}", exc_info=True)
+        return jsonify({"error": "服务器内部错误，无法提供文件下载。"}), 500
+
+
+if __name__ == '__main__':
+    # 为了确保 src 模块中的日志也能按预期工作 (如果它们也使用 logging.getLogger)
+    # 我们可以在这里调用 setup_logging 来配置根记录器
+    # 这样，即使 Flask 的 app.logger 有自己的配置，其他模块的日志也能输出
+    # 注意：如果 setup_logging 改变了根记录器的处理器，可能会影响 Flask 默认的日志行为
+    # 一个更稳健的方法可能是获取根记录器并确保其级别和处理器适合开发
+    if os.environ.get("WERKZEUG_RUN_MAIN") != "true": # 避免在 Flask 重载时重复配置
+        log_level = logging.DEBUG if app.debug else logging.INFO
+        # setup_logging(log_level) 
+        # 或者，更简单地确保 Flask logger 级别足够低以显示所有信息
+        app.logger.setLevel(logging.DEBUG if app.debug else logging.INFO)
+        # 如果 src 模块的日志不显示，则取消注释 setup_logging(log_level)
+        # 并确保 setup_logging 不会与 Flask 的日志系统冲突（例如，通过检查处理器是否已存在）
+        
+        # 临时：为确保 core_processor 等模块的日志能输出，我们调用 setup_logging
+        # 这会配置根记录器，Flask 的 app.logger 也会继承这个配置（或被覆盖）
+        # 这对于开发调试是可行的，但生产环境需要更精细的日志管理策略
+        setup_logging(logging.DEBUG if app.debug else logging.INFO)
+
+
+    app.run(host='0.0.0.0', port=5000, debug=True)

--- a/webapp/static/.gitkeep
+++ b/webapp/static/.gitkeep
@@ -1,0 +1,1 @@
+# This file ensures the directory is tracked by git.

--- a/webapp/static/script.js
+++ b/webapp/static/script.js
@@ -1,0 +1,164 @@
+document.addEventListener('DOMContentLoaded', function() {
+    // 获取 DOM 元素
+    const uploadForm = document.getElementById('uploadForm');
+    const fileInput = document.getElementById('fileInput');
+    const uploadStatus = document.getElementById('uploadStatus');
+    const resultsArea = document.getElementById('resultsArea');
+
+    // HTML 转义函数，用于安全地显示来自服务器的文本
+    function escapeHTML(str) {
+        if (typeof str !== 'string') return '';
+        return str.replace(/[&<>"']/g, function (match) {
+            return {
+                '&': '&amp;',
+                '<': '&lt;',
+                '>': '&gt;',
+                '"': '&quot;',
+                "'": '&#39;'
+            }[match];
+        });
+    }
+
+    // 获取并显示 Markdown 文件预览的函数
+    function fetchAndShowPreview(filename, listItemElement) {
+        // 移除旧的预览（如果存在）
+        const oldPreview = listItemElement.querySelector('.preview-container');
+        if (oldPreview) {
+            oldPreview.remove();
+        }
+
+        const previewContainer = document.createElement('div');
+        previewContainer.className = 'preview-container';
+        previewContainer.textContent = '正在加载预览...';
+        listItemElement.appendChild(previewContainer);
+
+        fetch(`/download/${encodeURIComponent(filename)}`) // 使用下载链接获取文件内容
+            .then(response => {
+                if (!response.ok) {
+                    throw new Error(`无法获取预览: ${response.status} ${response.statusText}`);
+                }
+                return response.text(); // 获取文本内容
+            })
+            .then(markdownText => {
+                // 使用 <pre> 标签来保留 Markdown 格式和换行
+                const preElement = document.createElement('pre');
+                preElement.className = 'markdown-preview';
+                preElement.textContent = markdownText;
+                previewContainer.innerHTML = ''; // 清空 "正在加载预览..."
+                previewContainer.appendChild(preElement);
+            })
+            .catch(error => {
+                console.error('获取预览失败:', error);
+                previewContainer.innerHTML = `<p class="error-message">预览失败: ${escapeHTML(error.message)}</p>`;
+            });
+    }
+
+    // 添加表单提交事件监听器
+    if (uploadForm) {
+        uploadForm.addEventListener('submit', function(event) {
+            event.preventDefault(); // 阻止表单的默认提价行为
+
+            // 清空之前的状态和结果
+            uploadStatus.innerHTML = '';
+            resultsArea.innerHTML = '<p>正在准备上传...</p>';
+
+            const files = fileInput.files;
+
+            // 检查是否有文件被选择
+            if (files.length === 0) {
+                resultsArea.innerHTML = '<p class="error-message">请至少选择一个文件。</p>';
+                return;
+            }
+
+            // 创建 FormData 对象
+            const formData = new FormData();
+            for (let i = 0; i < files.length; i++) {
+                formData.append('files[]', files[i]); // 'files[]' 必须与后端 Flask 期望的名称一致
+            }
+
+            uploadStatus.innerHTML = '正在上传文件...';
+
+            // 执行异步上传
+            fetch('/upload', { // URL 对应 Flask 中的上传路由
+                method: 'POST',
+                body: formData
+            })
+            .then(response => {
+                uploadStatus.innerHTML = '后端正在处理文件，请稍候...'; // 文件已上传，等待后端处理
+                if (!response.ok) {
+                    // 如果 HTTP 状态码不是 2xx，尝试解析错误信息
+                    return response.json().then(errData => {
+                        // 优先使用后端在 JSON 中明确提供的错误信息
+                        throw new Error(errData.error || `服务器返回错误: ${response.status}`);
+                    }).catch(() => {
+                        // 如果无法从 JSON 中解析错误，或者 JSON 本身就是问题，则抛出通用 HTTP 错误
+                        throw new Error(`服务器响应错误: ${response.status} ${response.statusText}`);
+                    });
+                }
+                return response.json(); // 解析 JSON 响应体
+            })
+            .then(data => {
+                uploadStatus.innerHTML = '处理完成！';
+                resultsArea.innerHTML = ''; // 清空之前的 "正在准备..." 或错误信息
+
+                if (Array.isArray(data) && data.length > 0) {
+                    const ul = document.createElement('ul');
+                    ul.className = 'results-list';
+
+                    data.forEach(item => {
+                        const li = document.createElement('li');
+                        li.className = 'result-item';
+                        
+                        let content = `<strong>${escapeHTML(item.original_filename)}:</strong> `;
+                        if (item.status === 'success') {
+                            content += `<span class="status-success">处理成功。</span> `;
+                            if (item.processed_filename) {
+                                const downloadLink = document.createElement('a');
+                                downloadLink.href = `/download/${encodeURIComponent(item.processed_filename)}`;
+                                downloadLink.textContent = `下载 ${escapeHTML(item.processed_filename)}`;
+                                downloadLink.className = 'download-link';
+                                downloadLink.setAttribute('download', item.processed_filename); // 建议浏览器下载
+
+                                const previewButton = document.createElement('button');
+                                previewButton.textContent = '预览 Markdown';
+                                previewButton.className = 'preview-button';
+                                // 使用闭包确保 filename 在 onclick 时是正确的
+                                previewButton.onclick = (function(filename, currentListItem) {
+                                    return function() { fetchAndShowPreview(filename, currentListItem); };
+                                })(item.processed_filename, li);
+
+                                content += downloadLink.outerHTML + ' ' + previewButton.outerHTML;
+                            } else {
+                                content += `<span>Markdown 内容已生成 (但未提供下载链接)。</span>`;
+                            }
+                        } else {
+                            content += `<span class="status-error">处理失败。</span> 原因: ${escapeHTML(item.message || '未知错误')}`;
+                        }
+                        li.innerHTML = content; // 设置 innerHTML 后，之前绑定的 onclick 可能需要重新处理，但这里是直接生成 HTML 字符串
+                        
+                        // 重新获取按钮并绑定事件（如果 previewButton.onclick 的方式在某些浏览器有问题）
+                        // 或者，在创建按钮后，先附加到 li，再通过 li.querySelector 找到按钮并绑定事件。
+                        // 当前的闭包方式通常是有效的。
+
+                        ul.appendChild(li);
+                    });
+                    resultsArea.appendChild(ul);
+                } else if (data.error) { // 处理整体上传错误（如果后端这样返回）
+                     resultsArea.innerHTML = `<p class="error-message">处理失败: ${escapeHTML(data.error)}</p>`;
+                } else if (Array.isArray(data) && data.length === 0) {
+                    resultsArea.innerHTML = '<p>已上传，但未返回任何处理结果。可能是所有文件都无法处理。</p>';
+                }
+                 else {
+                    resultsArea.innerHTML = '<p>未收到有效的处理结果或返回了非预期的格式。</p>';
+                }
+            })
+            .catch(error => {
+                console.error('上传或处理过程中发生错误:', error);
+                uploadStatus.innerHTML = '发生错误。';
+                resultsArea.innerHTML = `<p class="error-message">错误: ${escapeHTML(error.message)}</p>`;
+            });
+        });
+    } else {
+        console.error('上传表单 (uploadForm) 未在 DOM 中找到。');
+    }
+});

--- a/webapp/static/style.css
+++ b/webapp/static/style.css
@@ -1,0 +1,244 @@
+/* --- 全局与基础样式 --- */
+* {
+    box-sizing: border-box; /* 更直观的盒模型 */
+    margin: 0;
+    padding: 0;
+}
+
+body {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji"; /* 现代 sans-serif 字体栈 */
+    line-height: 1.6;
+    background-color: #f0f2f5; /* 柔和的浅灰色背景 */
+    color: #333; /* 主要文字颜色 */
+    padding: 20px; /* 页面边缘留白 */
+    display: flex;
+    justify-content: center; /* 水平居中容器 */
+    min-height: 100vh; /* 确保 body 至少和视口一样高 */
+}
+
+.container {
+    width: 100%;
+    max-width: 900px; /* 内容区域最大宽度 */
+    background: #ffffff; /* 内容区域白色背景 */
+    padding: 25px 30px;
+    border-radius: 8px; /* 圆角 */
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1); /* 更现代的阴影效果 */
+}
+
+/* --- 头部、主要内容区、页脚通用间距 --- */
+header, main, footer {
+    margin-bottom: 25px;
+}
+
+/* --- 头部样式 --- */
+header {
+    text-align: center;
+    border-bottom: 1px solid #e9ecef; /* 更柔和的分隔线 */
+    padding-bottom: 20px;
+}
+
+header h1 {
+    font-size: 2em; /* 调整标题大小 */
+    color: #2c3e50; /* 深蓝灰色标题 */
+    margin-bottom: 0.5em;
+}
+
+header p {
+    font-size: 1.1em;
+    color: #555;
+}
+
+/* --- 主要内容区域与区块 --- */
+.upload-section, .results-section {
+    margin-bottom: 30px;
+    padding: 20px;
+    border: 1px solid #dee2e6; /* 更柔和的边框 */
+    border-radius: 6px;
+    background-color: #f8f9fa; /* 区块内部浅背景色 */
+}
+
+.upload-section h2, .results-section h2 {
+    font-size: 1.5em;
+    color: #343a40; /* 深灰色区块标题 */
+    margin-top: 0;
+    margin-bottom: 15px;
+    border-bottom: 1px solid #ced4da;
+    padding-bottom: 10px;
+}
+
+/* --- 表单元素样式 --- */
+#uploadForm div {
+    margin-bottom: 15px; /* label 和 input 之间的间距 */
+}
+
+#uploadForm label {
+    display: block;
+    margin-bottom: 8px;
+    font-weight: bold;
+    color: #495057;
+}
+
+#fileInput {
+    display: block;
+    width: 100%; /* 文件输入框占满宽度 */
+    padding: 10px;
+    border: 1px solid #ced4da;
+    border-radius: 4px;
+    background-color: #fff;
+    font-size: 1em;
+    /* 考虑隐藏原始输入框，使用 label 触发，但这里保持简单 */
+}
+
+/* 统一按钮和特定链接的样式 */
+button, .preview-button, .download-link {
+    display: inline-block;
+    background-color: #007bff; /* Bootstrap 蓝色主题 */
+    color: white;
+    padding: 10px 20px; /* 调整内边距 */
+    border: none;
+    border-radius: 5px; /* 稍大的圆角 */
+    cursor: pointer;
+    text-decoration: none;
+    font-size: 1em;
+    font-weight: 500; /* 稍加粗 */
+    margin-right: 10px;
+    margin-top: 5px; /* 按钮之间的垂直间距 */
+    transition: background-color 0.2s ease-in-out; /* 平滑过渡效果 */
+}
+
+button:hover, .preview-button:hover, .download-link:hover {
+    background-color: #0056b3; /* 深蓝色悬停效果 */
+}
+
+button[type="submit"] {
+    background-color: #28a745; /* 提交按钮用绿色 */
+    font-weight: bold;
+}
+button[type="submit"]:hover {
+    background-color: #1e7e34; /* 深绿色悬停 */
+}
+
+.preview-button {
+    background-color: #6c757d; /* 预览按钮用灰色 */
+}
+.preview-button:hover {
+    background-color: #545b62;
+}
+
+/* --- 状态与结果显示区域 --- */
+.upload-status {
+    margin-top: 20px;
+    padding: 10px;
+    border-radius: 4px;
+    font-style: italic;
+    color: #495057; /* 中性色 */
+    background-color: #e9ecef; /* 状态背景 */
+}
+
+.results-list {
+    list-style-type: none; /* 移除列表默认项目符号 */
+    padding-left: 0;
+}
+
+.result-item {
+    padding: 12px;
+    border-bottom: 1px solid #e0e0e0; /* 列表项之间的分隔线 */
+    line-height: 1.8; /* 增加行高使内容更易读 */
+}
+
+.result-item:last-child {
+    border-bottom: none; /* 最后一项无下边框 */
+}
+
+.result-item strong { /* 原始文件名加粗 */
+    color: #343a40;
+}
+
+.status-success {
+    color: #198754; /* Bootstrap 成功绿色 */
+    font-weight: bold;
+}
+
+.status-error, .error-message {
+    color: #dc3545; /* Bootstrap 危险红色 */
+    font-weight: bold;
+}
+
+/* --- Markdown 预览区域 --- */
+.preview-container {
+    margin-top: 15px;
+    padding: 15px;
+    border: 1px dashed #adb5bd; /* 虚线边框 */
+    background-color: #f8f9fa; /* 与区块背景色一致或稍浅 */
+    border-radius: 4px;
+}
+
+.markdown-preview { /* <pre> 标签 */
+    white-space: pre-wrap;       /* 保留空白符序列，允许自动换行 */
+    word-wrap: break-word;       /* 在长单词或URL处强制换行 */
+    background-color: #e9ecef;   /* 预览区背景色，稍深于容器 */
+    color: #212529;              /* 预览区文字颜色 */
+    padding: 15px;
+    border-radius: 4px;
+    max-height: 400px;           /* 预览区最大高度 */
+    overflow-y: auto;            /* 超出则垂直滚动 */
+    font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, Courier, monospace; /* 优先使用系统等宽字体 */
+    font-size: 0.9em;            /* 稍小字体以容纳更多内容 */
+}
+
+/* --- 页脚样式 --- */
+footer {
+    text-align: center;
+    margin-top: 40px;
+    padding-top: 20px;
+    border-top: 1px solid #e9ecef;
+    font-size: 0.9em;
+    color: #6c757d; /* 页脚文字用次要颜色 */
+}
+
+/* --- （可选）响应式设计初步 --- */
+@media (max-width: 768px) {
+    .container {
+        padding: 20px 15px; /* 调整小屏幕容器内边距 */
+        margin: 10px; /* 确保小屏幕上容器不紧贴边缘 */
+    }
+
+    header h1 {
+        font-size: 1.8em;
+    }
+    header p {
+        font-size: 1em;
+    }
+
+    .upload-section h2, .results-section h2 {
+        font-size: 1.3em;
+    }
+
+    /* 使按钮和小部件在小屏幕上堆叠，并占据全部可用宽度 */
+    button, .preview-button, .download-link {
+        display: block;
+        width: 100%;
+        margin-bottom: 10px;
+        margin-right: 0; /* 移除右边距，因为它们现在是块级元素 */
+    }
+    
+    /* 如果有并排布局，可以在这里改为堆叠 */
+    /* 例如:
+    main {
+        display: flex;
+        flex-direction: column;
+    }
+    .upload-section, .results-section {
+        width: 100%; 
+    }
+    */
+}
+
+@media (max-width: 480px) {
+    header h1 {
+        font-size: 1.5em;
+    }
+    button, .preview-button, .download-link {
+        padding: 12px 15px; /* 调整按钮大小，使其更易于触摸 */
+    }
+}

--- a/webapp/templates/.gitkeep
+++ b/webapp/templates/.gitkeep
@@ -1,0 +1,1 @@
+# This file ensures the directory is tracked by git.

--- a/webapp/templates/index.html
+++ b/webapp/templates/index.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>智能文档清洗与 Markdown 转换</title>
+    <!-- 稍后将创建 style.css -->
+    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+</head>
+<body>
+    <div class="container">
+        <header>
+            <h1>智能文档清洗与 Markdown 转换工具</h1>
+            <p>上传您的 .docx 或 .pdf 文件，将其转换为 Markdown 格式。</p>
+        </header>
+
+        <main>
+            <section class="upload-section">
+                <h2>上传文件</h2>
+                <form id="uploadForm" enctype="multipart/form-data">
+                    <div>
+                        <label for="fileInput">选择文件 (可多选):</label>
+                        <input type="file" id="fileInput" name="files[]" multiple required>
+                    </div>
+                    <button type="submit">开始处理</button>
+                </form>
+                <div id="uploadStatus" class="upload-status" aria-live="polite"></div>
+            </section>
+
+            <section class="results-section">
+                <h2>处理结果</h2>
+                <div id="resultsArea" class="results-area">
+                    <p>处理完成后，结果将显示在此处。</p>
+                </div>
+            </section>
+        </main>
+
+        <footer>
+            <p>&copy; 2024 文档转换工具</p>
+        </footer>
+    </div>
+
+    <!-- 稍后将创建 script.js -->
+    <script src="{{ url_for('static', filename='script.js') }}"></script>
+</body>
+</html>

--- a/webapp/test_app.py
+++ b/webapp/test_app.py
@@ -1,0 +1,200 @@
+import os
+import unittest
+from unittest.mock import patch, MagicMock, mock_open
+import io
+import json
+import sys
+from flask import Flask, Response # Response 用于 test_download_file_success
+
+# 确保项目根目录在 sys.path 中
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from webapp.app import app # 导入 Flask 应用实例
+
+class TestAppRoutes(unittest.TestCase):
+
+    def setUp(self):
+        """在每个测试用例开始前运行"""
+        app.testing = True  # 开启测试模式
+        self.client = app.test_client() # 创建测试客户端
+
+        # 设置测试用的 UPLOAD_FOLDER 和 RESULTS_FOLDER
+        # 这些路径将在测试期间由 Flask 应用实例使用
+        # 注意：app.config['UPLOAD_FOLDER'] 和 app.config['RESULTS_FOLDER']
+        # 已经在 webapp.app 模块加载时被 os.path.join(BASE_DIR, 'uploads') 等方式设置。
+        # 我们这里可以覆盖它们为临时测试目录，或者依赖于它们是相对路径并在测试运行时是可写的。
+        # 为了测试的隔离性，最好使用临时目录，但这里我们遵循原始 app.py 的设置，
+        # 并假设这些目录（webapp/uploads, webapp/results）在测试环境中是可访问的。
+        # 如果测试涉及到实际的文件写入（例如，不 mock process_document_to_markdown），
+        # 则需要确保这些目录在测试前后被正确管理（创建/清理）。
+        # 当前的测试策略是 mock 掉会产生副作用的函数，所以实际文件写入不多。
+
+        # 确保环境变量已设置 (对于核心处理器中的检查)
+        # 这些值可以是 mock 值，因为实际的 LLM 调用会被 mock
+        os.environ['LLM_API_KEY'] = 'test_mock_api_key'
+        os.environ['LLM_API_ENDPOINT'] = 'http://mock.test.endpoint'
+        os.environ['LLM_MODEL_ID'] = 'test-model'
+
+
+    def tearDown(self):
+        """在每个测试用例结束后运行"""
+        # 清理可能在测试中创建的环境变量
+        del os.environ['LLM_API_KEY']
+        del os.environ['LLM_API_ENDPOINT']
+        del os.environ['LLM_MODEL_ID']
+        # 如果测试中创建了临时文件/目录，在此处清理
+
+    def test_index_route(self):
+        """测试根路径 (/) 是否成功渲染 index.html"""
+        response = self.client.get('/')
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b'智能文档清洗与 Markdown 转换工具', response.data) # 检查 HTML 内容
+        self.assertIn(b'选择文件 (可多选)', response.data)
+
+    @patch('webapp.app.process_document_to_markdown') # Mock 核心处理函数
+    def test_upload_single_docx_file_success(self, mock_process_document):
+        """测试成功上传单个 .docx 文件"""
+        # 配置 mock_process_document 的返回值
+        mock_md_filename = 'test_doc.md'
+        # 确保返回的是一个完整的模拟路径，或者仅是文件名，取决于 app.py 中如何使用它
+        # app.py 中的 os.path.basename(markdown_file_path) 会提取文件名
+        mock_process_document.return_value = os.path.join(app.config['RESULTS_FOLDER'], mock_md_filename)
+
+        data = {
+            'files[]': (io.BytesIO(b"dummy docx content"), 'test_doc.docx')
+        }
+        response = self.client.post('/upload', content_type='multipart/form-data', data=data)
+        
+        self.assertEqual(response.status_code, 200)
+        response_json = json.loads(response.data.decode('utf-8'))
+        self.assertIsInstance(response_json, list)
+        self.assertEqual(len(response_json), 1)
+        self.assertEqual(response_json[0]['original_filename'], 'test_doc.docx')
+        self.assertEqual(response_json[0]['status'], 'success')
+        self.assertEqual(response_json[0]['processed_filename'], mock_md_filename)
+        
+        # 验证 mock_process_document 被正确调用
+        args, kwargs = mock_process_document.call_args
+        actual_temp_upload_path = args[0] 
+        self.assertTrue(actual_temp_upload_path.startswith(app.config['UPLOAD_FOLDER']))
+        self.assertTrue(actual_temp_upload_path.endswith('test_doc.docx')) 
+        self.assertEqual(args[1], app.config['RESULTS_FOLDER'])
+
+    @patch('webapp.app.process_document_to_markdown')
+    def test_upload_multiple_files_success(self, mock_process_document):
+        """测试成功上传多个文件 (.docx, .pdf)"""
+        def side_effect_func(input_path, results_dir):
+            filename = os.path.basename(input_path)
+            # 模拟 process_document_to_markdown 返回的是完整路径
+            return os.path.join(results_dir, filename.replace('.docx', '.md').replace('.pdf', '.md'))
+        
+        mock_process_document.side_effect = side_effect_func
+
+        data = {
+            'files[]': [
+                (io.BytesIO(b"docx content"), 'doc1.docx'),
+                (io.BytesIO(b"pdf content"), 'doc2.pdf')
+            ]
+        }
+        response = self.client.post('/upload', content_type='multipart/form-data', data=data)
+        self.assertEqual(response.status_code, 200)
+        response_json = json.loads(response.data.decode('utf-8'))
+        self.assertEqual(len(response_json), 2)
+
+        # 检查第一个文件的结果
+        self.assertEqual(response_json[0]['original_filename'], 'doc1.docx')
+        self.assertEqual(response_json[0]['status'], 'success')
+        self.assertEqual(response_json[0]['processed_filename'], 'doc1.md')
+        
+        # 检查第二个文件的结果
+        self.assertEqual(response_json[1]['original_filename'], 'doc2.pdf')
+        self.assertEqual(response_json[1]['status'], 'success')
+        self.assertEqual(response_json[1]['processed_filename'], 'doc2.md')
+
+        # 验证 mock 调用次数
+        self.assertEqual(mock_process_document.call_count, 2)
+
+
+    @patch('webapp.app.process_document_to_markdown') 
+    def test_upload_unsupported_file_type(self, mock_process_document):
+        """测试上传不支持的文件类型"""
+        data = {'files[]': (io.BytesIO(b"text content"), 'test.txt')}
+        response = self.client.post('/upload', content_type='multipart/form-data', data=data)
+        self.assertEqual(response.status_code, 200) 
+        response_json = json.loads(response.data.decode('utf-8'))
+        self.assertEqual(len(response_json), 1)
+        self.assertEqual(response_json[0]['original_filename'], 'test.txt')
+        self.assertEqual(response_json[0]['status'], 'error')
+        self.assertIn("文件类型 '.txt' 不受支持", response_json[0]['message']) # 确保与 app.py 中的错误信息一致
+        mock_process_document.assert_not_called() 
+
+    def test_upload_no_files_field(self):
+        """测试上传请求中没有 'files[]' 字段的情况"""
+        # 发送一个空的 data，或者 data 中不包含 'files[]'
+        response = self.client.post('/upload', content_type='multipart/form-data', data={})
+        self.assertEqual(response.status_code, 400)
+        response_json = json.loads(response.data.decode('utf-8'))
+        self.assertIn('error', response_json)
+        self.assertEqual(response_json['error'], "请求中没有文件部分 (需要使用 'files[]' 作为字段名)")
+
+    def test_upload_empty_file_list(self):
+        """测试 'files[]' 字段存在但没有选择文件的情况"""
+        # Flask/Werkzeug 处理空文件列表的方式可能是在 request.files 中不包含该键，
+        # 或者 getlist 返回空列表。 app.py 中的逻辑是先检查 'files[]' not in request.files，
+        # 然后检查 uploaded_files 是否为空。
+        # 我们直接发送一个空的 files[] 列表（通过 werkzeug 的 FileStorage 模拟比较复杂，
+        # 但可以通过发送一个没有实际文件数据的 multipart 请求来间接触发）
+        # 或者，更简单地，测试 app.py 中 `if not uploaded_files or all(f.filename == '' for f in uploaded_files):` 这条路径
+        # 通过发送一个包含空文件名的文件字段
+        data = {'files[]': (io.BytesIO(b""), '')} # 文件名为空
+        response = self.client.post('/upload', content_type='multipart/form-data', data=data)
+        self.assertEqual(response.status_code, 400)
+        response_json = json.loads(response.data.decode('utf-8'))
+        self.assertIn('error', response_json)
+        self.assertEqual(response_json['error'], "没有选择文件")
+
+
+    @patch('webapp.app.process_document_to_markdown', return_value=None)
+    def test_upload_processing_fails(self, mock_process_document):
+        """测试核心处理函数 process_document_to_markdown 返回 None (处理失败)"""
+        data = {'files[]': (io.BytesIO(b"docx content"), 'fail_doc.docx')}
+        response = self.client.post('/upload', content_type='multipart/form-data', data=data)
+        self.assertEqual(response.status_code, 200)
+        response_json = json.loads(response.data.decode('utf-8'))
+        self.assertEqual(len(response_json), 1)
+        self.assertEqual(response_json[0]['status'], 'error')
+        self.assertIn('文件处理失败', response_json[0]['message'])
+
+    @patch('webapp.app.send_from_directory') 
+    def test_download_file_success(self, mock_send_from_directory):
+        """测试成功下载文件"""
+        mock_send_from_directory.return_value = Response("dummy md content", mimetype='text/markdown')
+
+        filename = 'test_doc.md'
+        response = self.client.get(f'/download/{filename}')
+        
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data, b"dummy md content")
+        self.assertEqual(response.mimetype, 'text/markdown')
+        mock_send_from_directory.assert_called_once_with(
+            app.config['RESULTS_FOLDER'], filename, as_attachment=True
+        )
+
+    # 这个测试依赖于 send_from_directory 的实际行为
+    def test_download_file_not_found(self):
+        """测试请求下载一个不存在的文件"""
+        non_existent_file = 'no_such_file_ever.md'
+        # 确保文件真的不存在于测试的 RESULTS_FOLDER
+        # (通常 setUp 会清理，或者我们可以选择一个几乎不可能存在的文件名)
+        file_path_to_check = os.path.join(app.config['RESULTS_FOLDER'], non_existent_file)
+        if os.path.exists(file_path_to_check):
+            os.remove(file_path_to_check) # 以防万一
+
+        response = self.client.get(f'/download/{non_existent_file}')
+        self.assertEqual(response.status_code, 404) 
+        # Flask 的 send_from_directory 在找不到文件时会正确地 abort(404)
+        # 默认的 404 页面是 HTML，所以不检查 JSON
+        self.assertIn(b'404 Not Found', response.data) # 检查是否是标准的 404 页面内容
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
本次更新引入了一个基于 Flask 的 Web 用户界面，允许你通过浏览器上传、处理 .docx 和 .pdf 文件，并将其转换为 Markdown 格式。

主要功能和变更包括：

- **Web 应用 (`webapp/`)**:
  - 我使用 Flask 框架搭建了后端 API，用于处理文件上传 (`/upload`) 和结果下载 (`/download`)。
  - 我重构了核心文档处理逻辑 (`core_processor.py`)，以便 CLI 和 Web 应用共享。
  - 前端我使用了 HTML, CSS, 和 JavaScript (`templates/index.html`, `static/style.css`, `static/script.js`)：
    - 支持多文件异步上传。
    - 动态显示处理状态和结果。
    - 提供处理后 Markdown 文件的下载链接和内容预览功能。
    - 我对界面进行了美化并实现了基础响应式设计。
- **测试**:
  - 我为 Flask API 端点添加了单元测试 (`webapp/test_app.py`)，并使用 mock 处理了核心逻辑。
- **文档 (`README.md`)**:
  - 我更新了项目结构说明。
  - 我添加了如何安装 Flask 依赖、配置环境变量以及启动和手动测试 Web 应用的详细指南。
- **代码质量**:
  - 我对新增和修改的代码进行了清理，完善了中文注释和文档字符串。
  - 我确保了 LLM 调用逻辑已恢复（移除了测试期间的 mock 代码）。

该 Web 界面为你提供了一种更直观、易用的方式来使用文档转换功能。